### PR TITLE
code-coverage measurement for core submodule

### DIFF
--- a/core/impl/pom.xml
+++ b/core/impl/pom.xml
@@ -62,4 +62,38 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>code-coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>emma-maven-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.maven.plugin</groupId>
+						<artifactId>emma4it-maven-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<artifactId>maven-clean-plugin</artifactId>
+						<configuration>
+							<filesets>
+								<fileset>
+									<directory>${basedir}/</directory>
+									<includes>
+										<include>**/*.ec</include>
+									</includes>
+								</fileset>
+							</filesets>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Hi, this commit will enable us to measure a code-coverage by just adding -Pcode-coverage to a maven call which runs tests. The results will be in core/impl/target/site/emma/ directory. Currently the code-coverage is quite low:

[class, %]   -> 19%  (3/16)!
[method, %] -> 15%  (26/174)!  
[block, %]  -> 10%  (230/2222)!
[line, %] -> 11%  (63/585)

After applying the pull request I will set this up in hudson for continuous feedback on code coverage.
