### PR TITLE
SEAMMAIL-30 jbossas-managed-7 profile broken

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -3,6 +3,7 @@
     <profile>
       <id>jboss-public-repository</id>
       <activation>
+        <activeByDefault>true</activeByDefault>
         <property>
           <name>jboss-public-repository</name>
           <value>!false</value>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -131,6 +131,19 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- slf4j version override for subethasmtp -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.5.10</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.5.10</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/testsuite/src/test/java/org/jboss/seam/mail/FreeMarkerMailMessageTest.java
+++ b/testsuite/src/test/java/org/jboss/seam/mail/FreeMarkerMailMessageTest.java
@@ -41,14 +41,11 @@ import org.jboss.seam.mail.core.SendFailedException;
 import org.jboss.seam.mail.core.enumerations.ContentDisposition;
 import org.jboss.seam.mail.core.enumerations.MessagePriority;
 import org.jboss.seam.mail.templating.freemarker.FreeMarkerTemplate;
+import org.jboss.seam.mail.util.Deployments;
 import org.jboss.seam.mail.util.EmailAttachmentUtil;
 import org.jboss.seam.mail.util.MailTestUtil;
-import org.jboss.seam.mail.util.MavenArtifactResolver;
 import org.jboss.seam.mail.util.SMTPAuthenticator;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.solder.resourceLoader.ResourceProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,15 +59,10 @@ import org.subethamail.wiser.Wiser;
 public class FreeMarkerMailMessageTest {
     @Deployment(name = "freemarker")
     public static Archive<?> createTestArchive() {
-        Archive<?> ar = ShrinkWrap.create(WebArchive.class, "test.war")
+        return Deployments.baseFreeMarkerDeployment()        
                 .addAsResource("template.text.freemarker", "template.text.freemarker")
                 .addAsResource("template.html.freemarker", "template.html.freemarker")
-                .addPackages(true, FreeMarkerMailMessageTest.class.getPackage())
-                .addAsLibraries(MavenArtifactResolver.resolve("org.subethamail:subethasmtp",
-                        "org.freemarker:freemarker", "org.jboss.solder:solder-impl"))
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsWebInfResource("seam-beans.xml");                
-        return ar;
+                .addPackages(true, FreeMarkerMailMessageTest.class.getPackage());
     }
 
     @Inject
@@ -106,10 +98,8 @@ public class FreeMarkerMailMessageTest {
         String version = "Seam 3";
         String mergedSubject = "Text Message from " + version + " Mail - " + uuid;
 
-        mailConfig.setServerHost("localHost");
-        mailConfig.setServerPort(8977);
-
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -159,10 +149,9 @@ public class FreeMarkerMailMessageTest {
         String subject = "HTML Message from Seam Mail - " + java.util.UUID.randomUUID().toString();
         String version = "Seam 3";
         EmailMessage emailMessage;
-        mailConfig.setServerHost("localHost");
-        mailConfig.setServerPort(8977);
-
+        
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -222,10 +211,9 @@ public class FreeMarkerMailMessageTest {
         String subject = "HTML+Text Message from Seam Mail - " + java.util.UUID.randomUUID().toString();
         String version = "Seam 3";
         EmailMessage emailMessage;
-        mailConfig.setServerHost("localHost");
-        mailConfig.setServerPort(8977);
-
+        
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -293,11 +281,10 @@ public class FreeMarkerMailMessageTest {
 
     @Test
     public void testSMTPSessionAuthentication() throws MessagingException, MalformedURLException {
-        String subject = "HTML+Text Message from Seam Mail - " + java.util.UUID.randomUUID().toString();
-
+        String subject = "HTML+Text Message from Seam Mail - " + java.util.UUID.randomUUID().toString();        
         mailConfig.setServerHost("localHost");
         mailConfig.setServerPort(8978);
-
+        
         Wiser wiser = new Wiser(mailConfig.getServerPort());
         wiser.getServer().setAuthenticationHandlerFactory(new EasyAuthenticationHandlerFactory(new SMTPAuthenticator("test", "test12!")));
         try {
@@ -338,11 +325,10 @@ public class FreeMarkerMailMessageTest {
         String uuid = java.util.UUID.randomUUID().toString();
         String subject = "Text Message from $version Mail - " + uuid;
         String version = "Seam 3";
-        mailConfig.setServerHost("localHost");
-        mailConfig.setServerPort(8977);
-
+        
         //Port is two off so this should fail
         Wiser wiser = new Wiser(mailConfig.getServerPort() + 2);
+        wiser.setHostname(mailConfig.getServerHost());        
         try {
             wiser.start();
 

--- a/testsuite/src/test/java/org/jboss/seam/mail/MailMessageTest.java
+++ b/testsuite/src/test/java/org/jboss/seam/mail/MailMessageTest.java
@@ -39,13 +39,10 @@ import org.jboss.seam.mail.core.MailConfig;
 import org.jboss.seam.mail.core.SendFailedException;
 import org.jboss.seam.mail.core.enumerations.ContentDisposition;
 import org.jboss.seam.mail.core.enumerations.MessagePriority;
+import org.jboss.seam.mail.util.Deployments;
 import org.jboss.seam.mail.util.MailTestUtil;
 import org.jboss.seam.mail.util.MailUtility;
-import org.jboss.seam.mail.util.MavenArtifactResolver;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.solder.resourceLoader.ResourceProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,17 +55,9 @@ import org.subethamail.wiser.Wiser;
 public class MailMessageTest {
     @Deployment(name = "mailMessage")
     public static Archive<?> createTestArchive() {
-        Archive<?> ar = ShrinkWrap
-                .create(WebArchive.class, "test.war")
+        return Deployments.baseDeployment()
                 .addAsResource("template.text.velocity")
-                .addPackages(true, MailMessageTest.class.getPackage())
-                // workaround for Weld EE embedded not properly reading Seam Solder jar
-                .addAsLibraries(MavenArtifactResolver.resolve("org.subethamail:subethasmtp",
-                        "org.jboss.solder:solder-impl"))
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsWebInfResource("seam-beans.xml");
-                
-        return ar;
+                .addPackages(true, MailMessageTest.class.getPackage());
     }
 
     @Inject
@@ -106,6 +95,7 @@ public class MailMessageTest {
         String messageId = "1234@seam.test.com";
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -157,6 +147,7 @@ public class MailMessageTest {
         EmailMessage emailMessage;
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -216,6 +207,7 @@ public class MailMessageTest {
         String subject = "HTML+Text Message from Seam Mail - " + java.util.UUID.randomUUID().toString();
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -294,6 +286,7 @@ public class MailMessageTest {
         String longCcAddress = "cCSometimesPeopleHaveNamesWhichAreALotLongerThanYouEverExpectedSomeoneToHaveSoItisGoodToTestUpTo100CharactersOrSo.hatty@jboss.org";
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -344,7 +337,8 @@ public class MailMessageTest {
 
         // Port is one off so this should fail
         Wiser wiser = new Wiser(mailConfig.getServerPort() + 1);
-
+        wiser.setHostname(mailConfig.getServerHost());
+        
         try {
             wiser.start();
 
@@ -373,7 +367,8 @@ public class MailMessageTest {
 
         // Port is one off so this should fail
         Wiser wiser = new Wiser(mailConfig.getServerPort() + 1);
-
+        wiser.setHostname(mailConfig.getServerHost());
+        
         try {
             wiser.start();
 
@@ -400,6 +395,7 @@ public class MailMessageTest {
         String messageId = "1234@seam.test.com";
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -450,6 +446,7 @@ public class MailMessageTest {
         String messageId = "1234@seam.test.com";
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 

--- a/testsuite/src/test/java/org/jboss/seam/mail/VelocityMailMessageTest.java
+++ b/testsuite/src/test/java/org/jboss/seam/mail/VelocityMailMessageTest.java
@@ -43,14 +43,11 @@ import org.jboss.seam.mail.core.enumerations.ContentDisposition;
 import org.jboss.seam.mail.core.enumerations.MessagePriority;
 import org.jboss.seam.mail.templating.velocity.CDIVelocityContext;
 import org.jboss.seam.mail.templating.velocity.VelocityTemplate;
+import org.jboss.seam.mail.util.Deployments;
 import org.jboss.seam.mail.util.EmailAttachmentUtil;
 import org.jboss.seam.mail.util.MailTestUtil;
-import org.jboss.seam.mail.util.MavenArtifactResolver;
 import org.jboss.seam.mail.util.SMTPAuthenticator;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.solder.resourceLoader.ResourceProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,17 +61,11 @@ import org.subethamail.wiser.Wiser;
 public class VelocityMailMessageTest {
     @Deployment(name = "velocity")
     public static Archive<?> createTestArchive() {
-        Archive<?> ar = ShrinkWrap
-                .create(WebArchive.class, "test.war")
+        return Deployments.baseVelocityDeployment()
                 .addAsResource("template.text.velocity")
                 .addAsResource("template.html.velocity")
                 .addAsWebResource("seam-mail-logo.png")
-                .addPackages(true, VelocityMailMessageTest.class.getPackage())
-                .addAsLibraries(MavenArtifactResolver.resolve("org.subethamail:subethasmtp",
-                "org.apache.velocity:velocity:1.6.4", "org.jboss.solder:solder-impl"))
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsWebInfResource("seam-beans.xml");              
-        return ar;
+                .addPackages(true, VelocityMailMessageTest.class.getPackage());
     }
 
     @Inject
@@ -166,6 +157,7 @@ public class VelocityMailMessageTest {
         EmailMessage emailMessage;
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -230,6 +222,7 @@ public class VelocityMailMessageTest {
         EmailMessage emailMessage;
 
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 
@@ -307,8 +300,9 @@ public class VelocityMailMessageTest {
 
         mailConfig.setServerHost("localhost");
         mailConfig.setServerPort(8978);
-
+        
         Wiser wiser = new Wiser(mailConfig.getServerPort());
+        wiser.setHostname(mailConfig.getServerHost());
         wiser.getServer().setAuthenticationHandlerFactory(
                 new EasyAuthenticationHandlerFactory(new SMTPAuthenticator("test", "test12!")));
         try {
@@ -353,11 +347,10 @@ public class VelocityMailMessageTest {
         String uuid = java.util.UUID.randomUUID().toString();
         String subject = "Text Message from $version Mail - " + uuid;
         String version = "Seam 3";
-        mailConfig.setServerHost("localHost");
-        mailConfig.setServerPort(8977);
 
         // Port is two off so this should fail
         Wiser wiser = new Wiser(mailConfig.getServerPort() + 2);
+        wiser.setHostname(mailConfig.getServerHost());
         try {
             wiser.start();
 

--- a/testsuite/src/test/java/org/jboss/seam/mail/util/Deployments.java
+++ b/testsuite/src/test/java/org/jboss/seam/mail/util/Deployments.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.seam.mail.util;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * Creates base deployments with all the required dependencies for the current container
+ * 
+ * @author Marek Schmidt
+ *
+ */
+public class Deployments {
+    public static WebArchive baseDeployment() {
+        
+        WebArchive archive = ShrinkWrap
+            .create(WebArchive.class, "test.war")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        if ("weld-ee-embedded-1.1".equals(System.getProperty("arquillian"))) {
+            archive.addAsWebInfResource("seam-beans.xml", "seam-beans.xml");
+            archive.addAsLibraries(MavenArtifactResolver.resolve("org.jboss.solder:solder-impl"));
+        }
+        else {
+            archive.addAsWebInfResource("seam-beans.xml", "classes/META-INF/seam-beans.xml");   
+            archive.addAsLibraries(MavenArtifactResolver.resolve("org.subethamail:subethasmtp",
+                    "org.jboss.solder:solder-impl", "org.slf4j:slf4j-simple", "com.google.guava:guava"));
+        }
+        
+        return archive;
+    }
+    
+    public static WebArchive baseVelocityDeployment() {
+        
+        WebArchive archive = ShrinkWrap
+            .create(WebArchive.class, "test.war")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        if ("weld-ee-embedded-1.1".equals(System.getProperty("arquillian"))) {
+            archive.addAsWebInfResource("seam-beans.xml", "seam-beans.xml");
+            archive.addAsLibraries(MavenArtifactResolver.resolve("org.jboss.solder:solder-impl"));
+        }
+        else {
+            archive.addAsWebInfResource("seam-beans.xml", "classes/META-INF/seam-beans.xml");   
+            archive.addAsLibraries(MavenArtifactResolver.resolve("org.subethamail:subethasmtp",
+                    "org.apache.velocity:velocity", "org.jboss.solder:solder-impl", "org.slf4j:slf4j-simple", "com.google.guava:guava"));
+        }
+        
+        return archive;
+    }
+    
+    public static WebArchive baseFreeMarkerDeployment() {
+        
+        WebArchive archive = ShrinkWrap
+            .create(WebArchive.class, "test.war")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        if ("weld-ee-embedded-1.1".equals(System.getProperty("arquillian"))) {
+            archive.addAsWebInfResource("seam-beans.xml", "seam-beans.xml");
+            archive.addAsLibraries(MavenArtifactResolver.resolve("org.jboss.solder:solder-impl"));
+        }
+        else {
+            archive.addAsWebInfResource("seam-beans.xml", "classes/META-INF/seam-beans.xml");   
+            archive.addAsLibraries(MavenArtifactResolver.resolve("org.subethamail:subethasmtp",
+                    "org.freemarker:freemarker", "org.jboss.solder:solder-impl", "org.slf4j:slf4j-simple", "com.google.guava:guava"));
+        }
+        
+        return archive;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/seam/mail/util/MavenArtifactResolver.java
+++ b/testsuite/src/test/java/org/jboss/seam/mail/util/MavenArtifactResolver.java
@@ -50,7 +50,9 @@ import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
 public class MavenArtifactResolver {
 
     public static Collection<JavaArchive> resolve(String qualifiedArtifactId) {
-        return DependencyResolvers.use(MavenDependencyResolver.class).loadMetadataFromPom("pom.xml")
+        return DependencyResolvers.use(MavenDependencyResolver.class)
+                .configureFrom("../settings.xml")
+                .loadMetadataFromPom("pom.xml")
                 .artifact(qualifiedArtifactId)
                 .resolveAs(JavaArchive.class);
     }


### PR DESCRIPTION
1. Make the AS7 profile tests run

note that the velocity tests still fail on AS7 with "java.lang.UnsupportedOperationException: Could not retrieve ServletContext from application attributes"
1. make the mailConfig usage more consistent throughout the tests
2. The second commit adds configuration of MavenDependencyResolver from settings.xml
